### PR TITLE
chore: Use `pnpm ci` in GHA

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: lts/*
 
       - name: Install
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
         run: pnpm run lint --fix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: lts/*
 
       - name: Install
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Typecheck
         run: pnpm run typecheck


### PR DESCRIPTION
<!--

Hey! Thanks for your contribution!

Just a quick note, this project is progressed mainly on Live Streams (https://github.com/nuxt/learn.nuxt.com#live-streaming). That means for significant changes, we want to demonstrate them on the stream so people can follow along the whole process.

**Please create an issue first before submiting PRs**. So that we can discuss about the directions and plans, to avoid wasted efforts. Thank you!

-->

元々使っていた `pnpm install` だと意図せずロックファイルが更新される可能性があるので、`--frozen-lockfile` オプションを追加しました。

(GitHub だと https://github.com/vuejs-jp/learn.nuxt.com/pull/56 がマージされたら自動で rebase されます)