### PR TITLE
fix: auto-importsセクションのstartingFileのパス修正

### DIFF
--- a/content/2.concepts/4.auto-imports/.template/index.ts
+++ b/content/2.concepts/4.auto-imports/.template/index.ts
@@ -1,7 +1,7 @@
 import type { GuideMeta } from '~/types/guides'
 
 export const meta: GuideMeta = {
-  startingFile: 'pages/index.vue',
+  startingFile: 'app.vue',
   features: {
     fileTree: true,
   },


### PR DESCRIPTION
<!--

Hey! Thanks for your contribution!

Just a quick note, this project is progressed mainly on Live Streams (https://github.com/nuxt/learn.nuxt.com#live-streaming). That means for significant changes, we want to demonstrate them on the stream so people can follow along the whole process.

**Please create an issue first before submiting PRs**. So that we can discuss about the directions and plans, to avoid wasted efforts. Thank you!

-->
Issue: #87 

自動インポートセクションで利用するGuideMetaのstartingFileを存在するファイルパスに修正しました。
とりあえずでapp.vueに入れましたが、他の箇所の方が良ければコメントお願いします