### PR TITLE
ルーティング章の Preview 表示で Web サーバーが立ち上がらない問題を修正

### DIFF
--- a/content/2.concepts/3.routing/.template/files/pages/posts/[id].vue
+++ b/content/2.concepts/3.routing/.template/files/pages/posts/[id].vue
@@ -1,1 +1,4 @@
 <!-- Challenge -->
+<template>
+  TODO
+</template>


### PR DESCRIPTION
<!--

Hey! Thanks for your contribution!

Just a quick note, this project is progressed mainly on Live Streams (https://github.com/nuxt/learn.nuxt.com#live-streaming). That means for significant changes, we want to demonstrate them on the stream so people can follow along the whole process.

**Please create an issue first before submiting PRs**. So that we can discuss about the directions and plans, to avoid wasted efforts. Thank you!

-->

ルーティング章に用意されている `pages/` ディレクトリ内に中身が空の .vue ファイルがあるため、WebContainers 内で `npm run dev` したときに↓のエラーが発生し、画面上では `Waiting for Nuxt to ready` のまま進まない問題がありました。

```
At least one <template> or <script> is required in a single file component.
```

問題となった .vue ファイルは https://github.com/vuejs-jp/learn.nuxt.com/pull/55 で追加したもので、経緯的にファイル削除できないのでエラー解消のために `<template>` タグを追加しました。