### PR TITLE
ハンズオン用リンクの削除

### DIFF
--- a/components/PanelDocs.vue
+++ b/components/PanelDocs.vue
@@ -167,17 +167,6 @@ router.beforeEach(() => {
             <div i-ph-arrow-square-out-fill />
             Ask your question
           </NuxtLink>
-          <!-- NOTE: remove when hands-on finished (will be held on 2024-10-19) -->
-          <NuxtLink
-            to="https://forms.gle/3WcTUaNsUEqPK4R19"
-            target="_blank"
-            flex="~ items-center gap-2"
-            text-inherit op75
-            hover="text-primary op100"
-          >
-            <div i-ph-arrow-square-out-fill />
-            take a questionnaire
-          </NuxtLink>
         </div>
       </article>
       <!-- Navigration Dropdown -->

--- a/components/PanelDocs.vue
+++ b/components/PanelDocs.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/return-in-computed-property -->
 <script setup lang="ts">
 import type { NavItem, ParsedContent } from '@nuxt/content'
 
@@ -64,32 +63,6 @@ const sourceUrl = computed(() =>
     : undefined,
 )
 
-// NOTE: remove when hands-on finished (will be held on 2024-10-19)
-const THREAD_ID_MAP: Readonly<Record<string, number>> = {
-  '0.index.md': 85,
-  '1.vue/1.index.md': 68,
-  '1.vue/2.reactivity/index.md': 71,
-  '1.vue/3.reactivity-2/index.md': 72,
-  '1.vue/4.composition-api/index.md': 73,
-  '1.vue/5.components/index.md': 74,
-  '1.vue/6.summary/index.md': 75,
-  '2.concepts/1.index.md': 76,
-  '2.concepts/2.app-vue/index.md': 77,
-  '2.concepts/3.routing/index.md': 78,
-  '2.concepts/4.auto-imports/index.md': 79,
-  '2.concepts/5.middleware/index.md': 80,
-  '2.concepts/6.layout/index.md': 81,
-  '2.concepts/7.rendering-modes/index.md': 82,
-  '2.concepts/8.state-manegement/index.md': 83,
-  '2.concepts/9.data-fetching/index.md': 84,
-}
-
-const threadUrl = computed<string | null>(() =>
-  page.value?._file && THREAD_ID_MAP[page.value._file]
-    ? `https://github.com/vuejs-jp/learn.nuxt.com/discussions/${THREAD_ID_MAP[page.value._file]}`
-    : null,
-)
-
 const docsEl = ref<HTMLElement | null>(null)
 const router = useRouter()
 router.beforeEach(() => {
@@ -145,7 +118,7 @@ router.beforeEach(() => {
             />
           </div>
         </div>
-        <div flex="~ items-center gap-4" border="t base dashed" mt-8 p3>
+        <div border="t base dashed" mt-8 p3>
           <NuxtLink
             v-if="sourceUrl"
             :to="sourceUrl" target="_blank"
@@ -155,17 +128,6 @@ router.beforeEach(() => {
           >
             <div i-ph-note-pencil-duotone />
             Edit this page
-          </NuxtLink>
-          <NuxtLink
-            v-if="threadUrl"
-            :to="threadUrl"
-            target="_blank"
-            flex="~ items-center gap-2"
-            text-inherit op75
-            hover="text-primary op100"
-          >
-            <div i-ph-arrow-square-out-fill />
-            Ask your question
           </NuxtLink>
         </div>
       </article>


### PR DESCRIPTION
<!--

Hey! Thanks for your contribution!

Just a quick note, this project is progressed mainly on Live Streams (https://github.com/nuxt/learn.nuxt.com#live-streaming). That means for significant changes, we want to demonstrate them on the stream so people can follow along the whole process.

**Please create an issue first before submiting PRs**. So that we can discuss about the directions and plans, to avoid wasted efforts. Thank you!

-->
Vue Fes Japan 2024 のハンズオン用に作成したリンクを削除しました。
内容は以下 PR の revert のみ。

- https://github.com/vuejs-jp/learn.nuxt.com/pull/86
- https://github.com/vuejs-jp/learn.nuxt.com/pull/89

local 環境で以下のように削除されていることは確認済みです↓

<img width="1198" alt="Nuxt_チュートリアルへようこそ！_-_Nuxt_Tutorial" src="https://github.com/user-attachments/assets/e1173736-0599-40a5-aae6-232a13ae3fa3">