### PR TITLE
chore-fix-typo-auto-imports

### DIFF
--- a/content/2.concepts/4.auto-imports/index.md
+++ b/content/2.concepts/4.auto-imports/index.md
@@ -17,7 +17,7 @@ Nuxt のディレクトリ構造の規約おかげで、 `components/`、`compos
 
 また、Nuxt はいくつかのコンポーネントやコンポーザブル、ユーティリティも提供しています。
 [ルーティング](/concepts/routing) のセクションで登場した `NuxtLink` コンポーネントがその一例です。\
-他にも、データフェッチで利用する `useFetch()` コンポーザブルやランタイムの設定にアクセスる `useRuntimeConfig()` コンポーザブル、ページナビゲーションのための `navigateTo()` ユーティリティ関数などがあります。\
+他にも、データフェッチで利用する `useFetch()` コンポーザブルやランタイムの設定にアクセスする `useRuntimeConfig()` コンポーザブル、ページナビゲーションのための `navigateTo()` ユーティリティ関数などがあります。\
 たくさんあるので、そのほかのものは Nuxt 公式ドキュメントの [Components](https://nuxt.com/docs/api/components)、[Composables](https://nuxt.com/docs/api/composables)、[Utils](https://nuxt.com/docs/api/utils) のセクションを参照してください。
 
 また、Nuxt では明示的なインポートもサポートしており、この場合は `#import` からインポートすることが可能です。


### PR DESCRIPTION
<!--

Hey! Thanks for your contribution!

Just a quick note, this project is progressed mainly on Live Streams (https://github.com/nuxt/learn.nuxt.com#live-streaming). That means for significant changes, we want to demonstrate them on the stream so people can follow along the whole process.

**Please create an issue first before submiting PRs**. So that we can discuss about the directions and plans, to avoid wasted efforts. Thank you!

-->

I found a typo in the "[auto-imports](https://nuxt.com/docs/guide/concepts/auto-imports)" chapter and created a PR to correct it.

before
`他にも、データフェッチで利用する `useFetch()` コンポーザブルやランタイムの設定にアクセスる`

after
`他にも、データフェッチで利用する `useFetch()` コンポーザブルやランタイムの設定にアクセスする`