### PR TITLE
docs: Nuxt 公式リポジトリへの統合に伴いREADMEを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,24 +18,23 @@ This repository is sponsored by [NuxtLabs Japan](https://zenadvisor.io/nuxtlabs-
 
 - https://github.com/nuxt/learn.nuxt.com/pull/217
 
-リポジトリ統合の様子は、下記YouTubeライブ配信でも紹介されています：
+リポジトリ統合の様子は、下記 YouTube ライブ配信でも紹介されています：
 
 - https://www.youtube.com/live/IL5dHHIxwhM?feature=share
 
-
 ## 📝 背景
 
-この日本語版リポジトリは、Nuxt公式チュートリアルの内容を日本語話者向けのハンズオンセミナーで活用することを目的に、Nuxt公式リポジトリをforkして翻訳を開始したものです。  
-プロジェクト立ち上げの背景については、以下のnote記事をご参照ください：  
+この日本語版リポジトリは、Nuxt 公式チュートリアルの内容を日本語話者向けのハンズオンセミナーで活用することを目的に、Nuxt 公式リポジトリを fork して翻訳を開始したものです。
+プロジェクト立ち上げの背景については、以下の note 記事をご参照ください：
 
 - https://note.com/ubugeeei/n/n2ac2b02043da
 
 ## 📦 現在のステータス
 
-このリポジトリはアーカイブされ、今後のメンテナンスは行われません。  
-参考資料として引き続き閲覧可能ですが、IssueやPull Requestの作成などはできなくなります。
+このリポジトリはアーカイブされ、今後のメンテナンスは行われません。
+参考資料として引き続き閲覧可能ですが、Issue や Pull Request の作成などはできなくなります。
 
-今後は Nuxt公式リポジトリをご利用ください：
+今後は Nuxt 公式リポジトリをご利用ください：
 
 - https://github.com/nuxt/learn.nuxt.com
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+>
+> このリポジトリは [Nuxt 公式リポジトリ（nuxt/learn.nuxt.com）](https://github.com/nuxt/learn.nuxt.com) にマージされました。\
+> 詳しくは下記をご覧ください！
+>
+> This repository has been merged into the [official Nuxt repository (nuxt/learn.nuxt.com)](https://github.com/nuxt/learn.nuxt.com). \
+> For more details, please see below!
+
 # Nuxt Tutorial Playground (ja)
 
 This repository is a clone of https://github.com/nuxt/learn.nuxt.com and is a Japanese version project.\

--- a/README.md
+++ b/README.md
@@ -5,3 +5,40 @@ Some of the content will be created in Japanese before the original.\
 We have received permission from [@antfu](https://github.com/antfu).\
 Special thanks to [@antfu](https://github.com/antfu) 💚.\
 This repository is sponsored by [NuxtLabs Japan](https://zenadvisor.io/nuxtlabs-japan).
+
+## learn.nuxt.com 日本語版（アーカイブ）
+
+このリポジトリは、[Nuxt公式チュートリアル](https://learn.nuxt.com/) の日本語翻訳版として運用されていました。
+
+## 🎉 Nuxt公式リポジトリにマージされました！
+
+この日本語翻訳プロジェクトの成果は、[Nuxt公式リポジトリ（nuxt/learn.nuxt.com）](https://github.com/nuxt/learn.nuxt.com) に正式に取り込まれました。
+
+該当のプルリクエストはこちらです：
+
+- https://github.com/nuxt/learn.nuxt.com/pull/217
+
+リポジトリ統合の様子は、下記YouTubeライブ配信でも紹介されています：
+
+- https://www.youtube.com/live/IL5dHHIxwhM?feature=share
+
+
+## 📝 背景
+
+この日本語版リポジトリは、Nuxt公式チュートリアルの内容を日本語話者向けのハンズオンセミナーで活用することを目的に、Nuxt公式リポジトリをforkして翻訳を開始したものです。  
+プロジェクト立ち上げの背景については、以下のnote記事をご参照ください：  
+
+- https://note.com/ubugeeei/n/n2ac2b02043da
+
+## 📦 現在のステータス
+
+このリポジトリはアーカイブされ、今後のメンテナンスは行われません。  
+参考資料として引き続き閲覧可能ですが、IssueやPull Requestの作成などはできなくなります。
+
+今後は Nuxt公式リポジトリをご利用ください：
+
+- https://github.com/nuxt/learn.nuxt.com
+
+## 🙏 ご協力ありがとうございました！
+
+本プロジェクトに関わってくださったすべての皆さまに、心より感謝いたします。


### PR DESCRIPTION
## 概要

Nuxt公式チュートリアルの日本語翻訳内容が [Nuxt公式リポジトリ（nuxt/learn.nuxt.com）](https://github.com/nuxt/learn.nuxt.com) に正式に取り込まれたことを受けて、本リポジトリのREADMEを更新し、アーカイブの準備を行いました。

## 変更内容

- README.md を更新し、以下の情報を追加
  - Nuxt公式リポジトリへの統合の報告
  - プロジェクト立ち上げの背景
  - 今後の案内（アーカイブ済みであることの明記）

## 関連リンク

- 翻訳内容がマージされたPR: https://github.com/nuxt/learn.nuxt.com/pull/217
- プロジェクト立ち上げに関するnote記事: https://note.com/ubugeeei/n/n2ac2b02043da
- ライブ配信: https://www.youtube.com/live/IL5dHHIxwhM?feature=share

## 今後の対応

このPRがマージされた後、以下の対応を行います：

- 本家へのリダイレクトの[PR](https://github.com/vuejs-jp/learn.nuxt.com/pull/98)のマージとリリース
- リポジトリをアーカイブ状態に設定（read-only）
